### PR TITLE
Pluralize zero

### DIFF
--- a/src/Issues.Gate/Rules/IssueGateRulesEvaluator.cs
+++ b/src/Issues.Gate/Rules/IssueGateRulesEvaluator.cs
@@ -145,7 +145,7 @@ namespace Issues.Gate.Rules
 
         private static string Pluralize(string text, int nrIssues)
         {
-            return nrIssues == 0 || nrIssues > 1 ? $"{text}s" : text;
+            return nrIssues == 1 ? text : $"{text}s";
         }
     }
 }

--- a/src/Issues.Gate/Rules/IssueGateRulesEvaluator.cs
+++ b/src/Issues.Gate/Rules/IssueGateRulesEvaluator.cs
@@ -145,7 +145,7 @@ namespace Issues.Gate.Rules
 
         private static string Pluralize(string text, int nrIssues)
         {
-            return nrIssues > 1 ? $"{text}s" : text;
+            return nrIssues == 0 || nrIssues > 1 ? $"{text}s" : text;
         }
     }
 }


### PR DESCRIPTION
Zero values were not being pluralized, eg: `0 issue` instead of `0 issues`

closes #28 