### PR TITLE
Fix description of created federal credential in setup

### DIFF
--- a/setup/_setup-deploy.sh
+++ b/setup/_setup-deploy.sh
@@ -276,7 +276,7 @@ createFederatedCredential() {
     echo -e "${warn_color}   Warning: The federated credential can only be used to deploy from $type"
     credential=$(jq -c -n '{name: $name ,issuer:"https://token.actions.githubusercontent.com",
             subject: $subject,
-            description:"$description", audiences: ["api://AzureADTokenExchange"]}' \
+            description: $description, audiences: ["api://AzureADTokenExchange"]}' \
         --arg subject "$subject" \
         --arg name "$federatedcredentialname" \
         --arg description "$description")


### PR DESCRIPTION
Description for federated credential was always `$description` instead of the actual value

Closes #37 