### PR TITLE
renable codeql for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           global-json-file: global.json
 
       - name: Initialize CodeQL
-        if: github.actor != 'dependabot[bot]'
         uses: github/codeql-action/init@f31a31c052207cc13b328d6295c5b728bb49568c
         with:
           languages: csharp
@@ -59,7 +58,6 @@ jobs:
         run: dotnet test src/GitHubActions.Gates.Samples.sln --no-build --verbosity normal --logger:"junit;LogFilePath=unit-tests.xml" --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       - name: Perform CodeQL Analysis
-        if: github.actor != 'dependabot[bot]'
         uses: github/codeql-action/analyze@f31a31c052207cc13b328d6295c5b728bb49568c
         with:
           category: "/language:csharp"


### PR DESCRIPTION
Otherwise OSSF complains some PRs do not have SAST enabled

Unsure if this isn't going to break with lack of permissions