### PR TITLE
Disable dependabot automatic rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
+    rebase-strategy: disabled
     schedule:
       interval: "monthly"
     groups:
@@ -11,6 +12,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/" # Location of package manifests
+    rebase-strategy: disabled
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
When there are 4-5 pull requests automatic rebasing only makes things slower since there is a thundering herd of rebases when merging PRs