### PR TITLE
Install java 17 for sonar scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
-          java-version: 17         
+          java-version: 17
+          distribution: zulu
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f31a31c052207cc13b328d6295c5b728bb49568c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           global-json-file: global.json
 
       - name: Setup Java JDK
-        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 // v3.13.0
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           java-version: 17         
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Setup Java JDK
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 // v3.13.0
+        with:
+          java-version: 17         
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f31a31c052207cc13b328d6295c5b728bb49568c
         with:


### PR DESCRIPTION
Sonar is complaining of [the runner default java version](https://github.com/tspascoal/GitHubActions.Gates.Samples/pull/118#issuecomment-1775056367)

<img width="595" alt="image" src="https://github.com/tspascoal/GitHubActions.Gates.Samples/assets/7847935/9fc842ea-be11-46eb-a364-bccc5737af5b">

Make sure we are using java 17