### PR TITLE
Split CI into 2 jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: dbg
         run: |
+          find "${{github.workspace}}/coverage"
           ls -la ${{github.workspace}}/coverage
           ls -la "${{github.workspace}}/coverage/coverage-merged.xml"
           cat "${{github.workspace}}/coverage/coverage-merged.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         if: always() && github.actor != 'dependabot[bot]'
         with:
-          filename: ${{github.workspace}}/coverage/coverage-merged.xml
+          filename: ${{github.workspace}}/coverage/coverage-*.xml
           badge: true
           format: 'markdown'
           output: 'both'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,13 @@ jobs:
         run: |
           dotnet tool install --global dotnet-coverage
           cd coverage
-          dotnet-coverage merge -o ${{github.workspace}}/coverage/coverage-merged.xml -f cobertura -r coverage.cobertura.xml
+          dotnet-coverage merge -o "${{github.workspace}}/coverage/coverage-merged.xml" -f cobertura -r coverage.cobertura.xml
 
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         if: always() && github.actor != 'dependabot[bot]'
         with:
-          filename: coverage/coverage-merged.xml
+          filename: ${{github.workspace}}/coverage/coverage-merged.xml
           badge: true
           format: 'markdown'
           output: 'both'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,6 @@ jobs:
           java-version: 17
           distribution: zulu
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@f31a31c052207cc13b328d6295c5b728bb49568c
-        with:
-          languages: csharp
-          queries: +security-extended,security-experimental,security-and-quality
-
       - name: Restore dependencies
         run: dotnet restore src/GitHubActions.Gates.Samples.sln
 
@@ -61,11 +55,6 @@ jobs:
 
       - name: Unit Tests
         run: dotnet test src/GitHubActions.Gates.Samples.sln --no-build --verbosity normal --logger:"junit;LogFilePath=unit-tests.xml" --collect:"XPlat Code Coverage" --results-directory ./coverage
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f31a31c052207cc13b328d6295c5b728bb49568c
-        with:
-          category: "/language:csharp"
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@f355d34d53ad4e7f506f699478db2dd71da9de5f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
           cd coverage
           dotnet-coverage merge -o "${{github.workspace}}/coverage/coverage-merged.xml" -f cobertura -r coverage.cobertura.xml
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/**  
+
       - name: dbg
         run: |
           ls -la ${{github.workspace}}/coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,14 @@ jobs:
           cd coverage
           dotnet-coverage merge -o "${{github.workspace}}/coverage/coverage-merged.xml" -f cobertura -r coverage.cobertura.xml
 
+      - name: dbg
+        run: ls -la "${{github.workspace}}/coverage/coverage-merged.xml"
+
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         if: always() && github.actor != 'dependabot[bot]'
         with:
-          filename: ${{github.workspace}}/coverage/coverage-*.xml
+          filename: ${{github.workspace}}/coverage/coverage-merged.xml
           badge: true
           format: 'markdown'
           output: 'both'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
-      security-events: write
 
     name: Build and Test
 
@@ -114,3 +113,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  code-scan:
+    permissions:
+      contents: read
+      checks: write
+      security-events: write
+
+    name: Code Scanning
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
+
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3
+        with:
+          global-json-file: global.json
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f31a31c052207cc13b328d6295c5b728bb49568c
+        with:
+          languages: csharp
+          queries: +security-extended,security-experimental,security-and-quality
+
+      - name: Restore dependencies
+        run: dotnet restore src/GitHubActions.Gates.Samples.sln
+
+      - name: Build
+        run: dotnet build src/GitHubActions.Gates.Samples.sln --no-restore /p:TreatWarningsAsErrors=true
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@f31a31c052207cc13b328d6295c5b728bb49568c
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,23 +73,11 @@ jobs:
           cd coverage
           dotnet-coverage merge -o "${{github.workspace}}/coverage/coverage-merged.xml" -f cobertura -r coverage.cobertura.xml
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: coverage/**  
-
-      - name: dbg
-        run: |
-          find "${{github.workspace}}/coverage"
-          ls -la ${{github.workspace}}/coverage
-          ls -la "${{github.workspace}}/coverage/coverage-merged.xml"
-          cat "${{github.workspace}}/coverage/coverage-merged.xml"
-
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         if: always() && github.actor != 'dependabot[bot]'
         with:
-          filename: '**/coverage/coverage-merged.xml'
+          filename: 'coverage/coverage-merged.xml'
           badge: true
           format: 'markdown'
           output: 'both'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
       - name: dbg
         run: |
+          ls -la ${{github.workspace}}/coverage
           ls -la "${{github.workspace}}/coverage/coverage-merged.xml"
           cat "${{github.workspace}}/coverage/coverage-merged.xml"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
           dotnet-coverage merge -o "${{github.workspace}}/coverage/coverage-merged.xml" -f cobertura -r coverage.cobertura.xml
 
       - name: dbg
-        run: ls -la "${{github.workspace}}/coverage/coverage-merged.xml"
+        run: |
+          ls -la "${{github.workspace}}/coverage/coverage-merged.xml"
+          cat "${{github.workspace}}/coverage/coverage-merged.xml"
 
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         if: always() && github.actor != 'dependabot[bot]'
         with:
-          filename: ${{github.workspace}}/coverage/coverage-merged.xml
+          filename: '**/coverage/coverage-merged.xml'
           badge: true
           format: 'markdown'
           output: 'both'

--- a/tests/DeployHours.Gate.Tests/DeployHours.Gate.Tests.csproj
+++ b/tests/DeployHours.Gate.Tests/DeployHours.Gate.Tests.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/GitHubActions.Gates.Framework.Tests/GitHubActions.Gates.Framework.Tests.csproj
+++ b/tests/GitHubActions.Gates.Framework.Tests/GitHubActions.Gates.Framework.Tests.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Issues.Gate.Tests/Issues.Gate.Tests.csproj
+++ b/tests/Issues.Gate.Tests/Issues.Gate.Tests.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request primarily modifies the GitHub Actions workflow file `.github/workflows/ci.yml`. The changes involve restructuring the workflow by removing the CodeQL analysis from the main job and creating a separate job for it. The new job, named `code-scan`, is responsible for the CodeQL analysis and has its own permissions and steps. The removed steps from the main job include the initialization of CodeQL and the performance of CodeQL analysis.

Here are the main changes:

* Removed `security-events: write` permission from the main job.
* Removed the initialization of CodeQL and related configurations from the main job.
* Removed the CodeQL analysis step from the main job.
* Added a new job `code-scan` with permissions `contents: read`, `checks: write`, and `security-events: write`. This job includes steps for checking out the code, setting up DotNet, initializing CodeQL, restoring dependencies, building the project, and performing the CodeQL analysis.


Downgrades coverlet to 6.0.0 to workaround bug https://github.com/coverlet-coverage/coverlet/issues/1625