### PR TITLE
Use Multiple Directories instead of directory in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,8 @@ updates:
         - '*'
 
   - package-ecosystem: "nuget"
-    directory: "/" # Location of package manifests
+    directories:
+      - 'src/**'
     rebase-strategy: disabled
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request includes a change to the Dependabot configuration file to improve the handling of NuGet package updates.


Configuration update:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L14-R15): Changed the `directory` key to `directories` and updated its value to include all subdirectories under `src`.